### PR TITLE
make git-commit adds manifests/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ push:
 
 .PHONY: git-commit
 git-commit:
-	git add catalog-manifests/
+	git add catalog-manifests/ manifests/
 	git commit -m "New catalog: $(CATALOG_VERSION)" --author="OpenShift SRE <aos-sre@redhat.com>"
 
 .PHONY: git-push


### PR DESCRIPTION
Was not included and it's required to update catalog and oprator manifests.