### PR TITLE
Push only the tag we created.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,8 @@ git-tag:
 
 .PHONY: git-push
 git-push: git-tag
-	git push && git push --tags
+	REMOTE=$(shell git status -sb | grep ^# | sed 's#.*[.]\([^./]*\)/[^./]*$$#\1#g'); \
+	git push && git push $$REMOTE $(GIT_TAG)
 
 .PHONY: version
 version:


### PR DESCRIPTION
Found that using `git push --tags` will push every tag.  It's a mess to clean up.
Just push one, which requires knowing the remote name.