### PR TITLE
SREP-1037 Generate SelectorSyncSet files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ isclean:
 .PHONY: manifestdir
 .SILENT: manifestdir
 manifestdir:
-	mkdir -p $(MANIFESTDIR)
+	mkdir -p $(MANIFESTDIR)/hive
 
 # create CatalogSource yaml
 .PHONY: manifests/catalog

--- a/Makefile
+++ b/Makefile
@@ -62,21 +62,27 @@ isclean:
 
 .PHONY: manifests/catalog
 manifests/catalog: catalog
-	mkdir -p manifests/
+	mkdir -p manifests/hive
 	# create CatalogSource yaml
 	TEMPLATE=scripts/templates/catalog.yaml; \
 	DEST=manifests/00-catalog.yaml; \
 	$(call process_template,.,$$TEMPLATE,$$DEST)
+	SSTEMPLATE=scripts/templates/catalog.selectorsyncset.yaml; \
+	SSDEST=manifests/hive/01-catalog.selectorsyncset.yaml; \
+	$(call process_template,.,$$SSTEMPLATE,$$SSDEST)
 
 # create yaml per operator
 .PHONY: manifests/operators
 manifests/operators: catalog
-	mkdir -p manifests/ ;\
+	mkdir -p manifests/hive ;\
 	for DIR in $(SOURCE_DIR)/**/ ; do \
 		SOURCE_NAME=$$(echo $$DIR | cut -d/ -f2); \
 		TEMPLATE=scripts/templates/operator.yaml; \
 		DEST=manifests/10-$${SOURCE_NAME}.yaml; \
 		$(call process_template,$$DIR,$$TEMPLATE,$$DEST); \
+		SSTEMPLATE=scripts/templates/operator.selectorsyncset.yaml; \
+		SSDEST=manifests/hive/20-$${SOURCE_NAME}.selectorsyncset.yaml; \
+		$(call process_template,$$DIR,$$SSTEMPLATE,$$SSDEST); \
 	done
 
 .PHONY: manifests

--- a/manifests/hive/01-catalog.selectorsyncset.yaml
+++ b/manifests/hive/01-catalog.selectorsyncset.yaml
@@ -1,0 +1,27 @@
+apiVersion: hive.openshift.io/v1alpha1
+kind: SelectorSyncSet
+metadata:
+  generation: 1
+  name: osd-operators-registry-catalogsource
+spec:
+  clusterDeploymentSelector:
+    matchLabels:
+      api.openshift.com/managed: "true"
+  resourceApplyMode: sync
+  resources:
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    metadata:
+      labels:
+        opsrc-datastore: "true"
+        opsrc-provider: redhat
+      name: osd-operators-registry
+      namespace: openshift-operator-lifecycle-manager
+    spec:
+      image: quay.io/openshift-sre/osd-operators-registry:master-477f255e9caf3d40b1da495862199907
+      displayName: OSD Operators
+      icon:
+        base64data: ""
+        mediatype: ""
+      publisher: Red Hat
+      sourceType: grpc

--- a/manifests/hive/20-dedicated-admin-operator.selectorsyncset.yaml
+++ b/manifests/hive/20-dedicated-admin-operator.selectorsyncset.yaml
@@ -1,0 +1,37 @@
+apiVersion: hive.openshift.io/v1alpha1
+kind: SelectorSyncSet
+metadata:
+  generation: 1
+  name: osd-dedicated-admin-operator
+spec:
+  clusterDeploymentSelector:
+    matchLabels:
+      api.openshift.com/managed: "true"
+  resourceApplyMode: sync
+  resources:
+  - apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: openshift-dedicated-admin
+    annotations:
+      openshift.io/node-selector: ""
+    labels:
+      openshift.io/cluster-monitoring: "true"
+  - apiVersion: operators.coreos.com/v1alpha2
+    kind: OperatorGroup
+    metadata:
+      name: dedicated-admin-operator
+      namespace: openshift-dedicated-admin
+    spec:
+      targetNamespaces:
+      - openshift-dedicated-admin
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: dedicated-admin-operator
+      namespace: openshift-dedicated-admin
+    spec:
+      channel: master
+      name: dedicated-admin-operator
+      source: osd-operators-registry
+      sourceNamespace: openshift-operator-lifecycle-manager

--- a/scripts/templates/catalog.selectorsyncset.yaml
+++ b/scripts/templates/catalog.selectorsyncset.yaml
@@ -1,0 +1,27 @@
+apiVersion: hive.openshift.io/v1alpha1
+kind: SelectorSyncSet
+metadata:
+  generation: 1
+  name: osd-operators-registry-catalogsource
+spec:
+  clusterDeploymentSelector:
+    matchLabels:
+      api.openshift.com/managed: "true"
+  resourceApplyMode: sync
+  resources:
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    metadata:
+      labels:
+        opsrc-datastore: "true"
+        opsrc-provider: redhat
+      name: #IMAGE_NAME#
+      namespace: #CATALOG_NAMESPACE#
+    spec:
+      image: #IMAGE_REGISTRY#/#IMAGE_REPOSITORY#/#IMAGE_NAME#:#CATALOG_VERSION#
+      displayName: OSD Operators
+      icon:
+        base64data: ""
+        mediatype: ""
+      publisher: Red Hat
+      sourceType: grpc

--- a/scripts/templates/operator.selectorsyncset.yaml
+++ b/scripts/templates/operator.selectorsyncset.yaml
@@ -1,0 +1,37 @@
+apiVersion: hive.openshift.io/v1alpha1
+kind: SelectorSyncSet
+metadata:
+  generation: 1
+  name: osd-#OPERATOR_NAME#
+spec:
+  clusterDeploymentSelector:
+    matchLabels:
+      api.openshift.com/managed: "true"
+  resourceApplyMode: sync
+  resources:
+  - apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: #OPERATOR_NAMESPACE#
+    annotations:
+      openshift.io/node-selector: ""
+    labels:
+      openshift.io/cluster-monitoring: "true"
+  - apiVersion: operators.coreos.com/v1alpha2
+    kind: OperatorGroup
+    metadata:
+      name: #OPERATOR_NAME#
+      namespace: #OPERATOR_NAMESPACE#
+    spec:
+      targetNamespaces:
+      - #OPERATOR_NAMESPACE#
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: #OPERATOR_NAME#
+      namespace: #OPERATOR_NAMESPACE#
+    spec:
+      channel: #CHANNEL#
+      name: #OPERATOR_NAME#
+      source: #IMAGE_NAME#
+      sourceNamespace: #CATALOG_NAMESPACE#


### PR DESCRIPTION

Added `SelectorSyncSet` generation for each operator, the output will be on manifests/ folder.

I kept the original operator.yaml templates and outputs so we can also deploy locally or in test environments without using `SyncSets`

I'm proposing `managed-osd` as the namespace where the `SelectorSyncSets` will be placed in a hive cluster, feel free to comment/propose another name.   