### PR TITLE
Defer OperatorGroup creation requests to operators

### DIFF
--- a/functions.mk
+++ b/functions.mk
@@ -31,3 +31,9 @@ define process_template
         -e "s/\#OPERATOR_NAMESPACE\#/$${OPERATOR_NAMESPACE}/g" \
         $(2) > $(3)
 endef
+
+define reset_vars
+    for v in ${RESET_VARS}; do \
+        unset $${v} ;\
+    done
+endef

--- a/scripts/templates/operator.yaml
+++ b/scripts/templates/operator.yaml
@@ -7,15 +7,6 @@ metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
 ---
-apiVersion: operators.coreos.com/v1alpha2
-kind: OperatorGroup
-metadata:
-  name: #OPERATOR_NAME#
-  namespace: #OPERATOR_NAMESPACE#
-spec:
-  targetNamespaces:
-  - #OPERATOR_NAMESPACE#
----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/scripts/templates/operatorgroup.yaml
+++ b/scripts/templates/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: #OPERATOR_NAME#
+  namespace: #OPERATOR_NAMESPACE#
+spec:
+  targetNamespaces:
+  - #OPERATOR_NAMESPACE#


### PR DESCRIPTION
Fixes #21

Recapping #21 here for context:

We have an issue with operators that might be deployed into a namespace
which already contains an `OperatorGroup` object. Previously, we would
always create such an object (previously in `templates/operator.yaml`,
now separated out into `templates/operatorgroup.yaml`), but that could
cause an issue at deploy time. In #21 and elsewhere there was discussion
of maintaining a list of namespaces where we'll need to create (and not)
an `OperatorGroup` object, but that has the overhead of maintaining that
list. We could apply some hueristic, but that may not be future proof.
Instead...

This change introduces a new variable for implementation in operators,
`${CREATE_OPERATOR_GROUP}`, which defaults to true (as in, defaulting to
creation of an `OperatorGroup`). Operators, such as
https://github.com/openshift/configure-alertmanager-operator can change
the `make env` target in `standard.mk` to `echo
CREATE_OPERATOR_GROUP=false` as an indication that the operator does not
require an `OperatorGroup` object created for it to operate.

Additionally, in this change, the `functions.mk` file has been amended
to add a `reset_vars` Make function. This has been created to DRY out
the places where these variables are being unset (the count is now up to
3), so that the list of variables can be maintained in the new
`RESET_VARS` (c.f., `Makefile`) variable.

Signed-off-by: Lisa Seelye <lseelye@redhat.com>