### PR TITLE
Allow operators to override MultiNamespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,12 @@ catalog: manifestdir operator-source
 			exit 3 ;\
 		else \
 			MULTI="$$(echo x$${MULTI_NAMESPACE} | tr [:upper:] [:lower:])" ;\
-			if [[ $$MULTI == "x" || $$MULTI == "xfalse" ]]; then \
-				MULTI_NAMESPACE="false" ;\
-			else \
+			if [[ $$MULTI == "xtrue" ]]; then \
 				echo "MULTI_NAMESPACE was $$MULTI_NAMESPACE for $${operator}, resetting to true for safety" ;\
 				MULTI_NAMESPACE="true" ;\
+			else \
+				echo "Found non-true value for MULTI_NAMESPACE ($$MULTI_NAMESPACE), resetting to false for safety" ;\
+				MULTI_NAMESPACE="false" ;\
 			fi ;\
 			unset MULTI ;\
 			./scripts/gen_operator_csv.py $(SOURCE_DIR)/$$operator $$OPERATOR_NAME $$OPERATOR_NAMESPACE $$OPERATOR_VERSION $$OPERATOR_IMAGE_URI $(CHANNEL) $$MULTI_NAMESPACE 1>/dev/null ;\

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /usr/bin/env bash -x
+SHELL := /usr/bin/env bash
 
 # Include project specific values file
 # Requires the following variables:
@@ -110,7 +110,7 @@ operator-source:
 
 .PHONY: catalog
 catalog: manifestdir operator-source
-	for operatorrepo in $(OPERATORS); do \
+	@for operatorrepo in $(OPERATORS); do \
 		$(call reset_vars) ;\
 		operator="$$(echo $$operatorrepo | cut -d / -f2)" ;\
 		echo "Building catalog for $$operator in $(SOURCE_DIR)/$$operator" ;\


### PR DESCRIPTION
Fixes #22

In Operators, allow them to use `MULTI_NAMESPACE` in their `make env` target. Set to `true` to override, leave blank or set to `false` to set false.

Signed-off-by: Lisa Seelye <lseelye@redhat.com>