### PR TITLE
Fix formatting issue on labels and annotations sections of selectorsyncset

### DIFF
--- a/scripts/templates/operator.selectorsyncset.yaml
+++ b/scripts/templates/operator.selectorsyncset.yaml
@@ -13,10 +13,10 @@ spec:
     kind: Namespace
     metadata:
       name: #OPERATOR_NAMESPACE#
-    annotations:
-      openshift.io/node-selector: ""
-    labels:
-      openshift.io/cluster-monitoring: "true"
+      annotations:
+        openshift.io/node-selector: ""
+      labels:
+        openshift.io/cluster-monitoring: "true"
   - apiVersion: operators.coreos.com/v1alpha2
     kind: OperatorGroup
     metadata:


### PR DESCRIPTION
Fix the labels and annotations sections that were misplaced in the operator selectorsyncset template

